### PR TITLE
The syck engine and YAML::ENGINE will be removed. Support ruby 2.2

### DIFF
--- a/lib/safe_yaml.rb
+++ b/lib/safe_yaml.rb
@@ -3,7 +3,7 @@ require "yaml"
 # This needs to be defined up front in case any internal classes need to base
 # their behavior off of this.
 module SafeYAML
-  YAML_ENGINE = defined?(YAML::ENGINE) ? YAML::ENGINE.yamler : "syck"
+  YAML_ENGINE = defined?(YAML::ENGINE) ? YAML::ENGINE.yamler : (defined?(Psych) && YAML == Psych ? "psych" : "syck")
 end
 
 require "set"


### PR DESCRIPTION
The syck engine and YAML::ENGINE will be removed.
https://bugs.ruby-lang.org/issues/8344